### PR TITLE
Successful build in Xcode 7.3/Swift 2

### DIFF
--- a/_source/PluginHelper.xcodeproj/project.pbxproj
+++ b/_source/PluginHelper.xcodeproj/project.pbxproj
@@ -191,7 +191,8 @@
 		40A524021AB69BAE0098046B /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0620;
+				LastSwiftUpdateCheck = 0730;
+				LastUpgradeCheck = 0730;
 				ORGANIZATIONNAME = "Aby Nimbalkar";
 				TargetAttributes = {
 					40A524091AB69BAE0098046B = {
@@ -303,6 +304,7 @@
 				CODE_SIGN_IDENTITY = "-";
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -372,6 +374,7 @@
 				);
 				INFOPLIST_FILE = PluginHelper/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.silverux.sketchplugins.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "PluginHelper/PluginHelper-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -390,6 +393,7 @@
 				);
 				INFOPLIST_FILE = PluginHelper/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.silverux.sketchplugins.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "PluginHelper/PluginHelper-Bridging-Header.h";
 			};
@@ -410,6 +414,7 @@
 				);
 				INFOPLIST_FILE = PluginHelperTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.silverux.sketchplugins.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PluginHelper.app/Contents/MacOS/PluginHelper";
 			};
@@ -426,6 +431,7 @@
 				);
 				INFOPLIST_FILE = PluginHelperTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.silverux.sketchplugins.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PluginHelper.app/Contents/MacOS/PluginHelper";
 			};
@@ -450,6 +456,7 @@
 				40A524281AB69BAE0098046B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		40A524291AB69BAE0098046B /* Build configuration list for PBXNativeTarget "PluginHelperTests" */ = {
 			isa = XCConfigurationList;
@@ -458,6 +465,7 @@
 				40A5242B1AB69BAE0098046B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/_source/PluginHelper/AppDelegate.swift
+++ b/_source/PluginHelper/AppDelegate.swift
@@ -17,22 +17,22 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     
     // MARK: - Handle opening the launcher file
     func application(sender: NSApplication, openFile filename: String) -> Bool {
-        println("Open file named: \(filename)")
+        print("Open file named: \(filename)")
         
         // After calling this method the parameters you send from Sketch will be available via SketchPlugin.params
         SketchPlugin.parseLauncherFile(filename, completion: {[unowned self] () -> Void in
             
             // For this example, we initialize and show HelloWindowController from Main.storyboard
             if self._helloWindowController == nil {
-                if let sb = NSStoryboard(name: "Main", bundle: NSBundle.mainBundle()) {
-                    self._helloWindowController = sb.instantiateControllerWithIdentifier("HelloWindow") as? NSWindowController
-                }
+                let sb = NSStoryboard(name: "Main", bundle: NSBundle.mainBundle())
+                self._helloWindowController = sb.instantiateControllerWithIdentifier("HelloWindow") as? NSWindowController
+                
             }
             
             self._helloWindowController!.window?.center()
             self._helloWindowController!.showWindow(nil)
             // Make the window float above everything else
-            self._helloWindowController!.window?.level = Int(CGWindowLevelForKey(Int32(kCGFloatingWindowLevelKey)))
+            self._helloWindowController!.window?.level = Int(CGWindowLevelForKey(CGWindowLevelKey.CursorWindowLevelKey))
             
         })
         

--- a/_source/PluginHelper/Base.lproj/Main.storyboard
+++ b/_source/PluginHelper/Base.lproj/Main.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="6751" systemVersion="14C1510" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15E65" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="6751"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10117"/>
     </dependencies>
     <scenes>
         <!--Application-->
@@ -672,7 +672,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="346" height="181"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9Xr-TW-IBX">
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9Xr-TW-IBX">
                                 <rect key="frame" x="65" y="116" width="216" height="17"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Hello, you have X Layers selected." id="EUo-Ua-qc1">
                                     <font key="font" metaFont="system"/>
@@ -680,8 +680,8 @@
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hx3-JJ-ZM9">
-                                <rect key="frame" x="103" y="53" width="141" height="32"/>
+                            <button verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hx3-JJ-ZM9">
+                                <rect key="frame" x="105" y="53" width="138" height="32"/>
                                 <buttonCell key="cell" type="push" title="Make Them Red" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="yPe-7J-gis">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -690,7 +690,7 @@
                                     <action selector="handleRedButton:" target="XfG-lQ-9wD" id="4fg-ui-cGC"/>
                                 </connections>
                             </button>
-                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="g0J-1K-Hel">
+                            <button verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="g0J-1K-Hel">
                                 <rect key="frame" x="132" y="20" width="83" height="32"/>
                                 <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="GLg-yj-lff">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>

--- a/_source/PluginHelper/HelloViewController.swift
+++ b/_source/PluginHelper/HelloViewController.swift
@@ -25,7 +25,11 @@ class HelloViewController: NSViewController {
             SketchPlugin.executeScriptAtPath(scriptPath)
             
             // Delete the .js file after it has executed
-            NSFileManager.defaultManager().removeItemAtPath(scriptPath, error: nil)
+            do {
+                try NSFileManager.defaultManager().removeItemAtPath(scriptPath)
+            } catch let error as NSError {
+                print("An error occurred: \(error)")
+            }
         }
         
         // Call terminate to close the helper app when you're done.

--- a/_source/PluginHelper/Info.plist
+++ b/_source/PluginHelper/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>
@@ -23,16 +25,12 @@
 			<false/>
 		</dict>
 	</array>
-	<key>LSUIElement</key>
-	<true/>
-	<key>CFBundleDevelopmentRegion</key>
-	<string>en</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIconFile</key>
 	<string></string>
 	<key>CFBundleIdentifier</key>
-	<string>com.silverux.sketchplugins.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
@@ -47,6 +45,8 @@
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>LSUIElement</key>
+	<true/>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2015 Aby Nimbalkar. All rights reserved.</string>
 	<key>NSMainStoryboardFile</key>

--- a/_source/PluginHelper/SketchPlugin.swift
+++ b/_source/PluginHelper/SketchPlugin.swift
@@ -28,18 +28,23 @@ class SketchPlugin:NSObject {
     }
     
     class func terminate() {
-        NSFileManager.defaultManager().removeItemAtPath(StaticVars.launcherFilePath, error: nil)
+        do {
+            try NSFileManager.defaultManager().removeItemAtPath(StaticVars.launcherFilePath)
+        } catch let error as NSError {
+            print(error)
+        }
         NSApplication.sharedApplication().terminate(nil)
     }
     
     class func parseLauncherFile(filePath:String, completion: (() -> Void)?=nil) {
         // Read the file as json
-        let errorPointer = NSErrorPointer()
-        let fileData = NSData(contentsOfFile: filePath, options: NSDataReadingOptions.allZeros, error: errorPointer)
-        let jsonDict: AnyObject! = NSJSONSerialization.JSONObjectWithData(fileData!, options: NSJSONReadingOptions.allZeros, error: errorPointer)
+     
+        let fileData =  NSData(contentsOfFile: filePath)
+        
+        let jsonDict: AnyObject! = try! NSJSONSerialization.JSONObjectWithData(fileData!, options: NSJSONReadingOptions())
         
         // Save the variables sent via Sketch as a global Dictionary
-        StaticVars.skParams = jsonDict as [String:AnyObject]
+        StaticVars.skParams = jsonDict as! [String:AnyObject]
         
         StaticVars.scriptFolder = params["scriptFolder"] as? String
         StaticVars.launcherFilePath = filePath
@@ -59,7 +64,11 @@ class SketchPlugin:NSObject {
     class func createPluginWithText(pluginText:String, pluginName:String="temp") -> String? {
         if let scriptFolder = params["scriptFolder"] as? String {
             let path = "\(scriptFolder)/\(pluginName).sketchplugin"
-            pluginText.writeToFile(path, atomically: true, encoding: NSUTF8StringEncoding, error: nil)
+            do {
+                try pluginText.writeToFile(path, atomically: true, encoding: NSUTF8StringEncoding)
+            } catch let error as NSError {
+                print(error)
+            }
             return path
         }
         return nil
@@ -68,7 +77,11 @@ class SketchPlugin:NSObject {
     class func createScriptWithText(scriptText:String, scriptName:String="temp") -> String? {
         if let scriptFolder = params["scriptFolder"] as? String {
             let path = "\(scriptFolder)/\(scriptName).js"
-            scriptText.writeToFile(path, atomically: true, encoding: NSUTF8StringEncoding, error: nil)
+            do {
+                try scriptText.writeToFile(path, atomically: true, encoding: NSUTF8StringEncoding)
+            } catch let error as NSError {
+                print(error)
+            }
             return path
         }
         return nil
@@ -79,7 +92,7 @@ class SketchPlugin:NSObject {
         let selector = Selector("runPluginAtURL:")
         if sketchApp.respondsToSelector(selector) {
             bringSketchInFocus()
-            XPerformSelector.perform(sketchApp, selector: selector, withObject: url!)
+            XPerformSelector.perform(sketchApp, selector: selector, withObject: url)
         }
     }
     

--- a/_source/PluginHelperTests/Info.plist
+++ b/_source/PluginHelperTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.silverux.sketchplugins.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
Updated so that the plugin will now build without error in newer
versions of Xcode and Swift. The absence of do/try/catch blocks threw
build errors. Also, if let has been deprecated, switched to just let.
Tested and works fine in Sketch 3.7.2, same functionality as before.
